### PR TITLE
Add memory watchers

### DIFF
--- a/watcher.ts
+++ b/watcher.ts
@@ -2,12 +2,11 @@
 
 import * as Process from './process';
 
-export class MemoryWatcher<T> {
+class Watcher<T> {
     /**  Current value of the watcher. */
     current: T;
     /**  The value of the watcher from the previous update cycle. */
     old: T;
-    protected type: string;
     protected module: string;
     protected address: Process.Address;
 
@@ -15,49 +14,11 @@ export class MemoryWatcher<T> {
      * Creates a watcher with the specified type.
      * @param moduleName Name of the module to read from.
      * @param address Relative address to read from.
-     * @returns {MemoryWatcher} The instance of a memory watcher with the specified parameters.
+     * @returns {Watcher} The instance of a memory watcher with the specified parameters.
      */
     constructor(moduleName: string, address: Process.Address) {
-        this.type = nameof<T>(); // Get watcher type as string
         this.module = moduleName;
         this.address = address;
-    }
-
-    /**
-     * Updates the watcher and returns `true` if the value has changed.
-     * @param processId ID of the process to read from.
-     * @returns {bool} Whether the value changed in the current update cycle.
-     */
-    update(processId: Process.ProcessId): bool {
-        this.old = this.current;
-        let changed = false;
-        let bufferSize = 4; // default 4 bytes of buffer
-        const baseAddress = Process.getModuleAddress(processId, this.module);
-
-        // Set the buffer size depending on the type
-        // AssemblyScript doesn't support switch cases on strings yet, so good ol' if chain it is
-        if (this.type == ('bool' || 'i8' || 'u8')) {
-            bufferSize = 1;
-        } else if (this.type == ('i16' || 'u16')) {
-            bufferSize = 2;
-        } else if (this.type == ('i32' || 'u32' || 'f32' || 'isize' || 'usize')) {
-            bufferSize = 4;
-        } else if (this.type == ('i64' || 'u64' || 'f64')) {
-            bufferSize = 8;
-        }
-
-
-        const buf = new ArrayBuffer(bufferSize);
-
-        if (Process.read(processId, (baseAddress + this.address), buf)) {
-            const value = usize.parse(String.UTF16.decode(buf));
-            if (this.current != value) {
-                changed = true;
-            }
-            this.current = (value as T);
-        }
-
-        return changed;
     }
 
     /**
@@ -69,13 +30,492 @@ export class MemoryWatcher<T> {
     }
 }
 
-export class StringWatcher {
+export class BoolWatcher extends Watcher<bool> {
+    /**
+     * Creates a watcher with the specified type.
+     * @param moduleName Name of the module to read from.
+     * @param address Relative address to read from.
+     * @returns {Watcher<bool>} The instance of a memory watcher of the type `bool` with the specified parameters.
+     */
+    constructor(moduleName: string, address: Process.Address) {
+        super(moduleName, address);
+        this.current = false;
+        this.old = false;
+    }
+
+    /**
+     * Updates the watcher and returns `true` if the value has changed.
+     * @param processId ID of the process to read from.
+     * @returns {bool} Whether the value changed in the current update cycle.
+     */
+    update(processId: Process.ProcessId): bool {
+        this.old = this.current;
+        let changed = false;
+        const baseAddress = Process.getModuleAddress(processId, this.module);
+
+        const buf = new ArrayBuffer(1);
+
+        if (Process.read(processId, (baseAddress + this.address), buf)) {
+            const value = bool.parse(String.UTF16.decode(buf));
+            if (this.current != value) {
+                changed = true;
+            }
+            this.current = value;
+        }
+
+        return changed;
+    }
+}
+
+export class I8Watcher extends Watcher<i8> {
+    /**
+     * Creates a watcher with the specified type.
+     * @param moduleName Name of the module to read from.
+     * @param address Relative address to read from.
+     * @returns {Watcher<i8>} The instance of a memory watcher of the type `i8` with the specified parameters.
+     */
+    constructor(moduleName: string, address: Process.Address) {
+        super(moduleName, address);
+        this.current = 0;
+        this.old = 0;
+    }
+
+    /**
+     * Updates the watcher and returns `true` if the value has changed.
+     * @param processId ID of the process to read from.
+     * @returns {bool} Whether the value changed in the current update cycle.
+     */
+    update(processId: Process.ProcessId): bool {
+        this.old = this.current;
+        let changed = false;
+        const baseAddress = Process.getModuleAddress(processId, this.module);
+
+        const buf = new ArrayBuffer(1);
+
+        if (Process.read(processId, (baseAddress + this.address), buf)) {
+            const value = i8.parse(String.UTF16.decode(buf));
+            if (this.current != value) {
+                changed = true;
+            }
+            this.current = value;
+        }
+
+        return changed;
+    }
+}
+
+export class I16Watcher extends Watcher<i16> {
+    /**
+     * Creates a watcher with the specified type.
+     * @param moduleName Name of the module to read from.
+     * @param address Relative address to read from.
+     * @returns {Watcher<i16>} The instance of a memory watcher of the type `i16` with the specified parameters.
+     */
+    constructor(moduleName: string, address: Process.Address) {
+        super(moduleName, address);
+        this.current = 0;
+        this.old = 0;
+    }
+
+    /**
+     * Updates the watcher and returns `true` if the value has changed.
+     * @param processId ID of the process to read from.
+     * @returns {bool} Whether the value changed in the current update cycle.
+     */
+    update(processId: Process.ProcessId): bool {
+        this.old = this.current;
+        let changed = false;
+        const baseAddress = Process.getModuleAddress(processId, this.module);
+
+        const buf = new ArrayBuffer(2);
+
+        if (Process.read(processId, (baseAddress + this.address), buf)) {
+            const value = i16.parse(String.UTF16.decode(buf));
+            if (this.current != value) {
+                changed = true;
+            }
+            this.current = value;
+        }
+
+        return changed;
+    }
+}
+
+export class I32Watcher extends Watcher<i32> {
+    /**
+     * Creates a watcher with the specified type.
+     * @param moduleName Name of the module to read from.
+     * @param address Relative address to read from.
+     * @returns {Watcher<i32>} The instance of a memory watcher of the type `i32` with the specified parameters.
+     */
+    constructor(moduleName: string, address: Process.Address) {
+        super(moduleName, address);
+        this.current = 0;
+        this.old = 0;
+    }
+
+    /**
+     * Updates the watcher and returns `true` if the value has changed.
+     * @param processId ID of the process to read from.
+     * @returns {bool} Whether the value changed in the current update cycle.
+     */
+    update(processId: Process.ProcessId): bool {
+        this.old = this.current;
+        let changed = false;
+        const baseAddress = Process.getModuleAddress(processId, this.module);
+
+        const buf = new ArrayBuffer(4);
+
+        if (Process.read(processId, (baseAddress + this.address), buf)) {
+            const value = i32.parse(String.UTF16.decode(buf));
+            if (this.current != value) {
+                changed = true;
+            }
+            this.current = value;
+        }
+
+        return changed;
+    }
+}
+
+export class I64Watcher extends Watcher<i64> {
+    /**
+     * Creates a watcher with the specified type.
+     * @param moduleName Name of the module to read from.
+     * @param address Relative address to read from.
+     * @returns {Watcher<i64>} The instance of a memory watcher of the type `i64` with the specified parameters.
+     */
+    constructor(moduleName: string, address: Process.Address) {
+        super(moduleName, address);
+        this.current = 0;
+        this.old = 0;
+    }
+
+    /**
+     * Updates the watcher and returns `true` if the value has changed.
+     * @param processId ID of the process to read from.
+     * @returns {bool} Whether the value changed in the current update cycle.
+     */
+    update(processId: Process.ProcessId): bool {
+        this.old = this.current;
+        let changed = false;
+        const baseAddress = Process.getModuleAddress(processId, this.module);
+
+        const buf = new ArrayBuffer(8);
+
+        if (Process.read(processId, (baseAddress + this.address), buf)) {
+            const value = i64.parse(String.UTF16.decode(buf));
+            if (this.current != value) {
+                changed = true;
+            }
+            this.current = value;
+        }
+
+        return changed;
+    }
+}
+
+export class ISizeWatcher extends Watcher<isize> {
+    /**
+     * Creates a watcher with the specified type.
+     * @param moduleName Name of the module to read from.
+     * @param address Relative address to read from.
+     * @returns {Watcher<isize>} The instance of a memory watcher of the type `isize` with the specified parameters.
+     */
+    constructor(moduleName: string, address: Process.Address) {
+        super(moduleName, address);
+        this.current = 0;
+        this.old = 0;
+    }
+
+    /**
+     * Updates the watcher and returns `true` if the value has changed.
+     * @param processId ID of the process to read from.
+     * @returns {bool} Whether the value changed in the current update cycle.
+     */
+    update(processId: Process.ProcessId): bool {
+        this.old = this.current;
+        let changed = false;
+        const baseAddress = Process.getModuleAddress(processId, this.module);
+
+        const buf = new ArrayBuffer(4);
+
+        if (Process.read(processId, (baseAddress + this.address), buf)) {
+            const value = isize.parse(String.UTF16.decode(buf));
+            if (this.current != value) {
+                changed = true;
+            }
+            this.current = value;
+        }
+
+        return changed;
+    }
+}
+
+export class U8Watcher extends Watcher<u8> {
+    /**
+     * Creates a watcher with the specified type.
+     * @param moduleName Name of the module to read from.
+     * @param address Relative address to read from.
+     * @returns {Watcher<u8>} The instance of a memory watcher of the type `u8` with the specified parameters.
+     */
+    constructor(moduleName: string, address: Process.Address) {
+        super(moduleName, address);
+        this.current = 0;
+        this.old = 0;
+    }
+
+    /**
+     * Updates the watcher and returns `true` if the value has changed.
+     * @param processId ID of the process to read from.
+     * @returns {bool} Whether the value changed in the current update cycle.
+     */
+    update(processId: Process.ProcessId): bool {
+        this.old = this.current;
+        let changed = false;
+        const baseAddress = Process.getModuleAddress(processId, this.module);
+
+        const buf = new ArrayBuffer(1);
+
+        if (Process.read(processId, (baseAddress + this.address), buf)) {
+            const value = u8.parse(String.UTF16.decode(buf));
+            if (this.current != value) {
+                changed = true;
+            }
+            this.current = value;
+        }
+
+        return changed;
+    }
+}
+
+export class U16Watcher extends Watcher<u16> {
+    /**
+     * Creates a watcher with the specified type.
+     * @param moduleName Name of the module to read from.
+     * @param address Relative address to read from.
+     * @returns {Watcher<u16>} The instance of a memory watcher of the type `u16` with the specified parameters.
+     */
+    constructor(moduleName: string, address: Process.Address) {
+        super(moduleName, address);
+        this.current = 0;
+        this.old = 0;
+    }
+
+    /**
+     * Updates the watcher and returns `true` if the value has changed.
+     * @param processId ID of the process to read from.
+     * @returns {bool} Whether the value changed in the current update cycle.
+     */
+    update(processId: Process.ProcessId): bool {
+        this.old = this.current;
+        let changed = false;
+        const baseAddress = Process.getModuleAddress(processId, this.module);
+
+        const buf = new ArrayBuffer(2);
+
+        if (Process.read(processId, (baseAddress + this.address), buf)) {
+            const value = u16.parse(String.UTF16.decode(buf));
+            if (this.current != value) {
+                changed = true;
+            }
+            this.current = value;
+        }
+
+        return changed;
+    }
+}
+
+export class U32Watcher extends Watcher<u32> {
+    /**
+     * Creates a watcher with the specified type.
+     * @param moduleName Name of the module to read from.
+     * @param address Relative address to read from.
+     * @returns {Watcher<u32>} The instance of a memory watcher of the type `u32` with the specified parameters.
+     */
+    constructor(moduleName: string, address: Process.Address) {
+        super(moduleName, address);
+        this.current = 0;
+        this.old = 0;
+    }
+
+    /**
+     * Updates the watcher and returns `true` if the value has changed.
+     * @param processId ID of the process to read from.
+     * @returns {bool} Whether the value changed in the current update cycle.
+     */
+    update(processId: Process.ProcessId): bool {
+        this.old = this.current;
+        let changed = false;
+        const baseAddress = Process.getModuleAddress(processId, this.module);
+
+        const buf = new ArrayBuffer(4);
+
+        if (Process.read(processId, (baseAddress + this.address), buf)) {
+            const value = u32.parse(String.UTF16.decode(buf));
+            if (this.current != value) {
+                changed = true;
+            }
+            this.current = value;
+        }
+
+        return changed;
+    }
+}
+
+export class U64Watcher extends Watcher<u64> {
+    /**
+     * Creates a watcher with the specified type.
+     * @param moduleName Name of the module to read from.
+     * @param address Relative address to read from.
+     * @returns {Watcher<u64>} The instance of a memory watcher of the type `u64` with the specified parameters.
+     */
+    constructor(moduleName: string, address: Process.Address) {
+        super(moduleName, address);
+        this.current = 0;
+        this.old = 0;
+    }
+
+    /**
+     * Updates the watcher and returns `true` if the value has changed.
+     * @param processId ID of the process to read from.
+     * @returns {bool} Whether the value changed in the current update cycle.
+     */
+    update(processId: Process.ProcessId): bool {
+        this.old = this.current;
+        let changed = false;
+        const baseAddress = Process.getModuleAddress(processId, this.module);
+
+        const buf = new ArrayBuffer(8);
+
+        if (Process.read(processId, (baseAddress + this.address), buf)) {
+            const value = u64.parse(String.UTF16.decode(buf));
+            if (this.current != value) {
+                changed = true;
+            }
+            this.current = value;
+        }
+
+        return changed;
+    }
+}
+
+export class USizeWatcher extends Watcher<usize> {
+    /**
+     * Creates a watcher with the specified type.
+     * @param moduleName Name of the module to read from.
+     * @param address Relative address to read from.
+     * @returns {Watcher<usize>} The instance of a memory watcher of the type `usize` with the specified parameters.
+     */
+    constructor(moduleName: string, address: Process.Address) {
+        super(moduleName, address);
+        this.current = 0;
+        this.old = 0;
+    }
+
+    /**
+     * Updates the watcher and returns `true` if the value has changed.
+     * @param processId ID of the process to read from.
+     * @returns {bool} Whether the value changed in the current update cycle.
+     */
+    update(processId: Process.ProcessId): bool {
+        this.old = this.current;
+        let changed = false;
+        const baseAddress = Process.getModuleAddress(processId, this.module);
+
+        const buf = new ArrayBuffer(4);
+
+        if (Process.read(processId, (baseAddress + this.address), buf)) {
+            const value = usize.parse(String.UTF16.decode(buf));
+            if (this.current != value) {
+                changed = true;
+            }
+            this.current = value;
+        }
+
+        return changed;
+    }
+}
+
+export class F32Watcher extends Watcher<f32> {
+    /**
+     * Creates a watcher with the specified type.
+     * @param moduleName Name of the module to read from.
+     * @param address Relative address to read from.
+     * @returns {Watcher<f32>} The instance of a memory watcher of the type `f32` with the specified parameters.
+     */
+    constructor(moduleName: string, address: Process.Address) {
+        super(moduleName, address);
+        this.current = 0.0;
+        this.old = 0.0;
+    }
+
+    /**
+     * Updates the watcher and returns `true` if the value has changed.
+     * @param processId ID of the process to read from.
+     * @returns {bool} Whether the value changed in the current update cycle.
+     */
+    update(processId: Process.ProcessId): bool {
+        this.old = this.current;
+        let changed = false;
+        const baseAddress = Process.getModuleAddress(processId, this.module);
+
+        const buf = new ArrayBuffer(4);
+
+        if (Process.read(processId, (baseAddress + this.address), buf)) {
+            const value = f32.parse(String.UTF16.decode(buf));
+            if (this.current != value) {
+                changed = true;
+            }
+            this.current = value;
+        }
+
+        return changed;
+    }
+}
+
+export class F64Watcher extends Watcher<f64> {
+    /**
+     * Creates a watcher with the specified type.
+     * @param moduleName Name of the module to read from.
+     * @param address Relative address to read from.
+     * @returns {Watcher<f64>} The instance of a memory watcher of the type `f64` with the specified parameters.
+     */
+    constructor(moduleName: string, address: Process.Address) {
+        super(moduleName, address);
+        this.current = 0.0;
+        this.old = 0.0;
+    }
+
+    /**
+     * Updates the watcher and returns `true` if the value has changed.
+     * @param processId ID of the process to read from.
+     * @returns {bool} Whether the value changed in the current update cycle.
+     */
+    update(processId: Process.ProcessId): bool {
+        this.old = this.current;
+        let changed = false;
+        const baseAddress = Process.getModuleAddress(processId, this.module);
+
+        const buf = new ArrayBuffer(8);
+
+        if (Process.read(processId, (baseAddress + this.address), buf)) {
+            const value = f64.parse(String.UTF16.decode(buf));
+            if (this.current != value) {
+                changed = true;
+            }
+            this.current = value;
+        }
+
+        return changed;
+    }
+}
+
+export class StringWatcher extends Watcher<string> {
     /**  Current value of the watcher. */
     current: string = "";
     /**  The value of the watcher from the previous update cycle. */
     old: string = "";
-    protected module: string;
-    protected address: Process.Address;
     protected length: u32;
     protected useUTF16: bool;
 
@@ -85,11 +525,10 @@ export class StringWatcher {
      * @param address Relative base address to use.
      * @param length The length of the string.
      * @param useUTF16 Decode the string as UTF-16. Defaults to `false`.
-     * @returns {StringWatcher} The instance of a memory watcher with the specified parameters.
+     * @returns {Watcher<string>} The instance of a memory watcher of type `string` with the specified parameters.
      */
     constructor(moduleName: string, address: Process.Address, length: u32, useUTF16: bool = false) {
-        this.module = moduleName;
-        this.address = address;
+        super(moduleName, address);
         this.length = length;
         this.useUTF16 = useUTF16;
     }
@@ -122,13 +561,5 @@ export class StringWatcher {
         }
 
         return changed;
-    }
-
-    /**
-     * Check if the value changed in this update cycle.
-     * @returns {bool} Whether the value changed this update cycle or not.
-     */
-    get changed(): bool {
-        return this.current != this.old;
     }
 }

--- a/watcher.ts
+++ b/watcher.ts
@@ -66,3 +66,67 @@ export class MemoryWatcher<T> {
         return this.current != this.old;
     }
 }
+
+export class StringWatcher {
+    /**  Current value of the watcher. */
+    current: string = "";
+    /**  The value of the watcher from the previous update cycle. */
+    old: string = "";
+    protected module: string;
+    protected address: Process.Address;
+    protected length: u32;
+    protected useUTF16: bool;
+
+    /**
+     * Creates a watcher with the specified type.
+     * @param moduleName Name of the module to read from.
+     * @param length The length of the string.
+     * @param useUTF16 Decode the string as UTF-16. Defaults to `false`.
+     * @param address Relative base address to use.
+     * @returns {StringWatcher} The instance of a memory watcher with the specified parameters.
+     */
+    constructor(moduleName: string, length: u32, address: Process.Address, useUTF16: bool = false) {
+        this.length = length;
+        this.module = moduleName;
+        this.address = address;
+        this.useUTF16 = useUTF16;
+    }
+
+    /**
+     * Updates the watcher and returns `true` if the value has changed.
+     * @param processId ID of the process to read from.
+     * @returns {bool} Whether the value changed in the current update cycle.
+     */
+    update(processId: Process.ProcessId): bool {
+        this.old = this.current;
+        let changed = false;
+        const bufferSize = this.length * 4;
+        let baseAddress = Process.getModuleAddress(processId, this.module);
+
+        const buf = new ArrayBuffer(bufferSize);
+
+        if (Process.read(processId, (baseAddress + this.address), buf)) {
+            let value = "";
+            if (this.useUTF16) {
+                value = String.UTF16.decode(buf);
+            } else {
+                value = String.UTF8.decode(buf);
+            }
+
+            if (value != this.current) {
+                changed = true;
+            }
+            this.current = value;
+        }
+
+        return changed;
+    }
+
+    /**
+     * Check if the value changed in this update cycle.
+     * @returns {bool} Whether the value changed this update cycle or not.
+     */
+    get changed(): bool {
+        return this.current != this.old;
+    }
+}

--- a/watcher.ts
+++ b/watcher.ts
@@ -509,11 +509,13 @@ export class F64Watcher extends Watcher<f64> {
     }
 }
 
-export class StringWatcher extends Watcher<string> {
+export class StringWatcher {
     /**  Current value of the watcher. */
     current: string = "";
     /**  The value of the watcher from the previous update cycle. */
     old: string = "";
+    protected module: string;
+    protected address: Process.Address;
     protected length: u32;
     protected useUTF16: bool;
 
@@ -526,7 +528,8 @@ export class StringWatcher extends Watcher<string> {
      * @returns {Watcher<string>} The instance of a memory watcher of type `string` with the specified parameters.
      */
     constructor(moduleName: string, address: Process.Address, length: u32, useUTF16: bool = false) {
-        super(moduleName, address);
+        this.module = moduleName;
+        this.address = address;
         this.length = length;
         this.useUTF16 = useUTF16;
     }

--- a/watcher.ts
+++ b/watcher.ts
@@ -1,0 +1,68 @@
+import * as Process from './process';
+
+export class MemoryWatcher<T> {
+    /**  Current value of the watcher. */
+    current: number;
+    /**  The value of the watcher from the previous update cycle. */
+    old: number;
+    protected type: string;
+    protected module: string;
+    protected address: Process.Address;
+
+    /**
+     * Creates a watcher with the specified type.
+     * @param moduleName Name of the module to read from.
+     * @param address Relative address to read from.
+     * @returns {MemoryWatcher} The instance of a memory watcher with the specified parameters.
+     */
+    constructor(moduleName: string, address: Process.Address) {
+        this.type = nameof<T>(); // Get watcher type as string
+        this.module = moduleName;
+        this.address = address;
+    }
+
+    /**
+     * Updates the watcher and returns `true` if the value has changed.
+     * @param processId ID of the process to read from.
+     * @returns {bool} Whether the value changed in the current update cycle.
+     */
+    update(processId: Process.ProcessId): bool {
+        this.old = this.current;
+        let changed = false;
+        let bufferSize = 4; // default 4 bytes of buffer
+        let baseAddress = Process.getModuleAddress(processId, this.module);
+
+        // Set the buffer size depending on the type
+        // AssemblyScript doesn't support switch cases on strings yet, so good ol' if chain it is
+        if (this.type == ('bool' || 'i8' || 'u8')) {
+            bufferSize = 1;
+        } else if (this.type == ('i16' || 'u16')) {
+            bufferSize = 2;
+        } else if (this.type == ('i32' || 'u32' || 'f32' || 'isize' || 'usize')) {
+            bufferSize = 4;
+        } else if (this.type == ('i64' || 'u64' || 'f64')) {
+            bufferSize = 8;
+        }
+
+
+        const buf = new ArrayBuffer(bufferSize);
+
+        if (Process.read(processId, (baseAddress + this.address), buf)) {
+            const value = usize.parse(String.UTF16.decode(buf));
+            if (this.current != value) {
+                changed = true;
+            }
+            this.current = value;
+        }
+
+        return changed;
+    }
+
+    /**
+     * Check if the value changed in this update cycle.
+     * @returns {bool} Whether the value changed this update cycle or not.
+     */
+    get changed(): bool {
+        return this.current != this.old;
+    }
+}

--- a/watcher.ts
+++ b/watcher.ts
@@ -1,5 +1,3 @@
-/// <reference path="D:\asr-ts-autosplitter\node_modules\assemblyscript\std\types\assembly\index.d.ts"/>
-
 import * as Process from './process';
 
 class Watcher<T> {


### PR DESCRIPTION
This PR adds simple ASL-like memory watchers.

## Things to note
* Each type has it's own class <sub>mostly because I wasn't fully sure how else to do it</sub>
* Doesn't currently read pointer paths
* Not fully tested against UTF-16 strings

## Usage
Basic memory watcher for the `u16` type:
```ts
import "asr-assemblyscript/runtime";
import { U16Watcher } from "asr-assemblyscript/watcher";
import * as Process from 'asr-assemblyscript/process';
import * as Timer from "asr-assemblyscript/timer";

let processId: Process.ProcessId = 0;
const load = new U16Watcher("P4G.exe", 0x51BCD12);

export function update(): void {
  if (processId === 0) {
    processId = Process.attach("P4G.exe");
    if (processId === 0) {
      return;
    }
  }

  if (!Process.isOpen(processId)) {
    Process.detach(processId);
    processId = 0;
    return;
  }

  load.update(processId)
  Timer.setVariable("load", load.current.toString());
}
```

String watcher:
```ts
import "asr-assemblyscript/runtime";
import { StringWatcher } from "asr-assemblyscript/watcher";
import * as Process from 'asr-assemblyscript/process';
import * as Timer from "asr-assemblyscript/timer";

let processId: Process.ProcessId = 0;
const map = new StringWatcher("hw.dll", 0x808130, 10);

export function update(): void {
  if (processId === 0) {
    processId = Process.attach("hl.exe");
    if (processId === 0) {
      return;
    }
  }

  if (!Process.isOpen(processId)) {
    Process.detach(processId);
    processId = 0;
    return;
  }

  map.update(processId)
  Timer.setVariable("map", map.current);
}
```